### PR TITLE
Add support for hiding encrypted sections in RSS feed (index.xml)

### DIFF
--- a/hugo-encryptor.py
+++ b/hugo-encryptor.py
@@ -50,3 +50,32 @@ if __name__ == '__main__':
 
                 with open(fullpath, 'w') as f:
                     f.write(str(soup))
+
+    xmlpath = './public/index.xml'
+
+    soup = BeautifulSoup(open(xmlpath),'xml')
+    descriptions = soup('description')
+
+    for description in descriptions:
+
+        if description.string is not None:
+            post = BeautifulSoup(description.string,'html.parser')
+            block = post.find('hugo-encryptor')
+
+            if block is None:
+                pass
+
+            else:      
+                language = block.find('p')
+
+                if language.string == 'The following content is password protected.':
+                    prompt = BeautifulSoup('<p><i>The following content is password protected. Please view it on the original website.</i></p>','html.parser')
+                
+                else:
+                    prompt = BeautifulSoup('<p><i>以下内容被密码保护。请前往原网站查看。</i></p>','html.parser')
+                
+                block.replace_with(prompt)
+                description.string.replace_with(str(post))
+
+    with open(xmlpath, 'w') as f:
+        f.write(str(soup))


### PR DESCRIPTION
For some Hugo users like me, it is a need to generate full-content RSS feeds, rather than just the default post summary. So we change `<description>{{ .Summary | html }}</description>` in [Hugo embedded rss.xml](https://gohugo.io/templates/rss/#the-embedded-rssxml) to `<description>{{ .Content | html }}</description>` to achieve it.

However, in that case, Hugo-Encryptor won't encrypt sections in RSS feed (index.xml) and thus may lead to leakage of encrypted information. So I tried to hide those encrypted sections in `index.xml` and give readers a prompt.