### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM jfloff/alpine-python:latest-slim
+WORKDIR /blog
+ADD requirements.txt /
+ADD hugo-encryptor.py /
+RUN /entrypoint.sh -a libxslt -b libxslt-dev -b libxml2-dev -b g++ \
+    && rm -f /requirements.txt
+CMD ["python", "/hugo-encryptor.py"]


### PR DESCRIPTION
当使用 GitHub Actions 等 CI 进行自动构建时，会有大量时间浪费在安装 Python 依赖上，通过打包为 Docker 镜像可以大幅加快构建速度。

Usage:

```bash
cd /path/to/your/blog/

docker run -v $(pwd):/blog hugo_encryptor:latest
```