### PR TITLE
split decrypt javascript into a single file

### DIFF
--- a/decrypt.js
+++ b/decrypt.js
@@ -1,0 +1,74 @@
+const _do_decrypt = function (encrypted, password) {
+    let key = CryptoJS.enc.Utf8.parse(password);
+    let iv = CryptoJS.enc.Utf8.parse(password.substr(16));
+
+    let decrypted_data = CryptoJS.AES.decrypt(encrypted, key, {
+        iv: iv,
+        mode: CryptoJS.mode.CBC,
+        padding: CryptoJS.pad.Pkcs7
+    });
+    return decrypted_data.toString(CryptoJS.enc.Utf8);
+};
+
+const _click_handler = function (element) {
+    let parent = element.parentNode.parentNode;
+    let encrypted = parent.querySelector(
+        ".hugo-encryptor-cipher-text").innerText;
+    let password = parent.querySelector(
+        ".hugo-encryptor-input").value;
+    password = CryptoJS.MD5(password).toString();
+
+    let index = -1;
+    let elements = document.querySelectorAll(
+        ".hugo-encryptor-container");
+    for (index = 0; index < elements.length; ++index) {
+        if (elements[index].isSameNode(parent)) {
+            break;
+        }
+    }
+
+    let decrypted = "";
+    try {
+        decrypted = _do_decrypt(encrypted, password);
+    } catch (err) {
+        console.error(err);
+        alert("Failed to decrypt.");
+        return;
+    }
+
+    if (!decrypted.includes("--- DON'T MODIFY THIS LINE ---")) {
+        alert("Incorrect password.");
+        return;
+    }
+
+    let storage = localStorage;
+
+    let key = location.pathname + ".password." + index;
+    storage.setItem(key, password);
+    parent.innerHTML = decrypted;
+}
+
+window.onload = () => {
+    let index = -1;
+    let elements = document.querySelectorAll(
+        ".hugo-encryptor-container");
+
+    while (1) {
+        ++index;
+
+        let key = location.pathname + ".password." + index;
+        let password = localStorage.getItem(key);
+
+        if (!password) {
+            break;
+
+        } else {
+            console.log("Found password for part " + index);
+
+            let parent = elements[index];
+            let encrypted = parent.querySelector(".hugo-encryptor-cipher-text").innerText;
+            let decrypted = _do_decrypt(encrypted, password);
+            elements[index].innerHTML = decrypted;
+        }
+    }
+};

--- a/hugo-encryptor.py
+++ b/hugo-encryptor.py
@@ -50,82 +50,8 @@ if __name__ == '__main__':
 
             if len(blocks):
                 soup.body.append(soup.new_tag("script", src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/crypto-js.js"))
-                script_tag = soup.new_tag("script")
-                script_tag.string = """
-const _do_decrypt = function(encrypted, password) {
-  let key = CryptoJS.enc.Utf8.parse(password);
-  let iv = CryptoJS.enc.Utf8.parse(password.substr(16));
-
-  let decrypted_data = CryptoJS.AES.decrypt(encrypted, key, {
-    iv: iv,
-    mode: CryptoJS.mode.CBC,
-    padding: CryptoJS.pad.Pkcs7
-  });
-  return decrypted_data.toString(CryptoJS.enc.Utf8);
-};
-
-const _click_handler = function(element) {
-  let parent = element.parentNode.parentNode;
-  let encrypted = parent.querySelector(
-    ".hugo-encryptor-cipher-text").innerText;
-  let password = parent.querySelector(
-    ".hugo-encryptor-input").value;
-  password = CryptoJS.MD5(password).toString();
-
-  let index = -1;
-  let elements = document.querySelectorAll(
-    ".hugo-encryptor-container");
-  for (index = 0; index < elements.length; ++index) {
-    if (elements[index].isSameNode(parent)) {
-      break;
-    }
-  }
-
-  let decrypted = "";
-  try {
-    decrypted = _do_decrypt(encrypted, password);
-  } catch (err) {
-    console.error(err);
-    alert("Failed to decrypt.");
-    return;
-  }
-
-  if (!decrypted.includes("--- DON'T MODIFY THIS LINE ---")) {
-    alert("Incorrect password.");
-    return;
-  }
-
-  let storage = localStorage;
-
-  let key = location.pathname + ".password." + index;
-  storage.setItem(key, password);
-  parent.innerHTML = decrypted;
-}
-
-window.onload = () => {
-  let index = -1;
-  let elements = document.querySelectorAll(
-    ".hugo-encryptor-container");
-
-  while (1) {
-    ++index;
-
-    let key = location.pathname + ".password." + index;
-    let password = localStorage.getItem(key);
-
-    if (!password) {
-      break;
-
-    } else {
-      console.log("Found password for part " + index);
-
-      let parent = elements[index];
-      let encrypted = parent.querySelector(".hugo-encryptor-cipher-text").innerText;
-      let decrypted = _do_decrypt(encrypted, password);
-      elements[index].innerHTML = decrypted;
-    }
-  }
-};"""
+                script_tag = soup.new_tag("script", src="/decrypt.js")
+                
                 soup.body.append(script_tag)
 
             with open(fullpath, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
What:
- split the javascript used for decryption into a single file called decrypt.js

Pros:
- shrink html size. A script block with `src="/decrypt.js"` instead of full js content in every encrypted page.
- better organization. A single js file can benefit from syntax highlight and js dev tools, and the main python file can focus on its job.

Cons:
- End users need to copy decrypt.js to their hugo static folder (but we can substitute the `src="/decrypt.js"` for a jsdelivr link to get around this)