### PR TITLE
change cipher to aes-128-gcm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pycrypto==2.6.1
+pycryptodome~=3.9.9
 beautifulsoup4==4.7.1
 lxml==4.6.3


### PR DESCRIPTION
What this does:

1. split the javascript used for decryption into a seperate file
2. change cipher from aes-cbc to aes-gcm

About 1, pros and cons are described in #20 

Reasons for 2:

- see #18 

Dependencies changed:

- CryptoJS doesn't support aes-gcm, I use [forge](https://github.com/digitalbazaar/forge) to fulfil the requirement
- pycrypto doesn't support aes-gcm, I use [pycryptodome](https://github.com/Legrandin/pycryptodome) to fulfil that